### PR TITLE
fix: link for docs is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Any questions?** Here is our official [forum](https://forum.babylonjs.com/).
 
-You can find documentation for the controls [here](https://doc.babylonjs.com/features/controls)
+You can find documentation for the controls [here](https://doc.babylonjs.com/features/featuresDeepDive/controls)
 
 ## Running locally
 


### PR DESCRIPTION
Tiny fix. The link for babylon.js dodument is wrong.